### PR TITLE
Add Tally intergration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@web3-react/walletlink-connector": "^6.1.6",
     "apollo-boost": "^0.4.9",
     "bnc-notify": "^1.5.1",
-    "bnc-onboard": "^1.19.2",
+    "bnc-onboard": "^1.37.0", 
     "classnames": "^2.2.6",
     "eslint-import-resolver-typescript": "^2.3.0",
     "ethers": "^5.3.0",

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -120,6 +120,7 @@ const wallets = (chainId: number) => {
       rpcUrl: RPC_URL,
     },
     { walletName: 'hyperpay' },
+    { walletName: 'tally' },
     { walletName: 'wallet.io', rpcUrl: RPC_URL },
     { walletName: 'atoken' },
   ];


### PR DESCRIPTION
Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.
